### PR TITLE
middleman v4 support

### DIFF
--- a/lib/middleman/dragonfly_thumbnailer/extension.rb
+++ b/lib/middleman/dragonfly_thumbnailer/extension.rb
@@ -3,11 +3,9 @@ require 'dragonfly'
 module Middleman
   module DragonflyThumbnailer
     class Extension < Middleman::Extension
-      attr_accessor :images
 
       def initialize(app, options_hash = {}, &block)
         super
-        @images = []
         configure_dragonfly
       end
 
@@ -34,16 +32,15 @@ module Middleman
         image.meta['original_path'] = path
         image.meta['geometry'] = geometry
         image = image.thumb(geometry)
-        images << image
+
+        persist_file(image) if app.build?
+
         image
       end
 
-      def after_build(builder)
-        images.each do |image|
-          builder.say_status :create, build_path(image)
-          path = absolute_build_path(image)
-          image.to_file(path).close
-        end
+      def persist_file(image)
+        path = absolute_build_path(image)
+        image.to_file(path).close
       end
 
       helpers do

--- a/lib/middleman/dragonfly_thumbnailer/extension.rb
+++ b/lib/middleman/dragonfly_thumbnailer/extension.rb
@@ -56,6 +56,20 @@ module Middleman
 
           image_tag(url, options)
         end
+
+        def thumb_url(path, geometry)
+          image = extensions[:dragonfly_thumbnailer].thumb(path, geometry)
+          return unless image
+
+          if environment == :development
+            url = image.b64_data
+          else
+            url = extensions[:dragonfly_thumbnailer].build_path(image)
+          end
+
+          image_path url
+        end
+
       end
 
       private

--- a/middleman-dragonfly_thumbnailer.gemspec
+++ b/middleman-dragonfly_thumbnailer.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.6'
   spec.add_development_dependency 'rake'
 
-  spec.add_runtime_dependency('middleman-core', ['~> 3.2'])
-  spec.add_runtime_dependency('dragonfly', ['>= 1.0.0'])
+  spec.add_runtime_dependency('middleman-core')
+  spec.add_runtime_dependency('dragonfly')
 end


### PR DESCRIPTION
Somehow in middleman v4 the app is reinitialized on after_build, so the array of images accumulated in build process are emptied on after_build callback, then they are never processed on build fase.

solution: 
- Remove the images accessor and process on `thumb` method only when middleman is on building fase.
